### PR TITLE
Improved nav bar and login/registration functionality

### DIFF
--- a/All project code/index.js
+++ b/All project code/index.js
@@ -49,7 +49,12 @@ app.use(express.static(__dirname + '/resources'));
 
 // Sets "/" location to redirect to /login page. We may want to change this to /home (or have /home located here at /)
 app.get("/", (req, res) => {
-    res.redirect("/landing");
+    if(req.session.user) {
+        res.redirect("/main");
+    }
+    else {
+        res.redirect("/landing");
+    }
 });
 
 app.get("/register", (req, res) => {
@@ -68,7 +73,13 @@ app.post("/register", async (req, res) => {
     
     await db.any(query, [username, hash])
     .then(() => {
-        res.redirect("/login?success=true");
+        req.session.user = username;
+        req.session.user.flight_api_key = process.env.flight_api_key;
+        req.session.save();
+        res.render("pages/main", {
+            message: "Your account was sucessfully created! Happy Hunting!",
+            error: false
+        });
     })
     .catch(() => {
         res.render("pages/register", {
@@ -191,7 +202,10 @@ app.get("/main", (req, res) => {
 
 app.get("/logout", (req, res) => {
     req.session.destroy();
-    res.render("pages/logout");
+    res.render("pages/landing", {
+        message: "You have been successfully logged out",
+        error: false
+    });
 });
 
 app.listen(3000);

--- a/All project code/views/pages/landing.ejs
+++ b/All project code/views/pages/landing.ejs
@@ -1,5 +1,5 @@
 <%- include ('../partials/header') %>
-<%- include ('../partials/menu') %>
+<%- include ('../partials/message') %>
     <main>
         <div class="container pb-4">
             <div class="row align-items-center">

--- a/All project code/views/pages/main.ejs
+++ b/All project code/views/pages/main.ejs
@@ -1,5 +1,6 @@
 <%- include ('../partials/header') %>
 <%- include ('../partials/menu') %>
+<%- include ('../partials/message') %>
 
 <main>
     <div class="container">

--- a/All project code/views/partials/menu.ejs
+++ b/All project code/views/partials/menu.ejs
@@ -9,12 +9,6 @@
           <a class="nav-link" href = "/profile">Profile</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href = "/login">Login</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href = "/register">Register</a>
-        </li>
-        <li class="nav-item">
           <a class="nav-link" href = "/logout">Logout</a>
         </li>
       </ul>


### PR DESCRIPTION
Closes #46 

Changes:

Landing Page: If a user has not logged in, they have no reason to see the nav bar because the only two actions they can take (login/register) have their own buttons on that page already

Registration: If a user creates an account, there's no reason for them to have to immediately log in again. Instead this just automatically logs them in and takes them to the home page with a success message.

Nav Bar: If a user is already logged in, they should not need to log in or register again (in fact this can create some weird bugs), so those pages shouldn't be available from the navbar. Instead a user will just log out and reenter the website. (Although this still doesn't stop them from manually navigating to those pages)

Logout: A page specifically for showing a logout message is redundant and unnecessary (plus it gives them access to the nav bar which they don't need if they are logged out and can't access those pages anyway). Instead this just redirects them back to the landing page with a success message for logging out

Session: Whenever the root ("/") endpoint is called it now checks if a user is logged in and automatically takes them to the homepage instead so they don't have to go back through the login sequence. This allows users to stay logged in for the entire session