### PR TITLE
SECURITY: Fixes race-conditions in login form, and makes failed login feedback equivalent.

### DIFF
--- a/All project code/index.js
+++ b/All project code/index.js
@@ -106,13 +106,13 @@ app.post("/login", (req, res) => {
     const password = req.body.password;
 
     const query = "SELECT * FROM users WHERE username = $1";
+    // For security reasons, the user should receieve the same feedback on a login fail, regardless of why the login failed.
+    const failed_login_feedback = "Incorrect username or password."
 
     // Queries the database for existing users, and then checks if password matches before logging in.
     db.any(query, [username])
     .then(async (user) => {
 
-        // For security reasons, the user should receieve the same feedback on a login fail, regardless of why the login failed.
-        const failed_login_feedback = "Incorrect username or password."
         //Checks if an account registered under the given username exists
         if (user[0] == null)
         {
@@ -143,7 +143,7 @@ app.post("/login", (req, res) => {
     .catch((err) => {
         console.log(err.message);
         res.render("pages/login", {
-            message: err.message,
+            message: failed_login_feedback,
             error: true,
         });
     });

--- a/All project code/index.js
+++ b/All project code/index.js
@@ -107,14 +107,17 @@ app.post("/login", (req, res) => {
 
     const query = "SELECT * FROM users WHERE username = $1";
 
+    // Queries the database for existing users, and then checks if password matches before logging in.
     db.any(query, [username])
     .then(async (user) => {
 
+        // For security reasons, the user should receieve the same feedback on a login fail, regardless of why the login failed.
+        const failed_login_feedback = "Incorrect username or password."
         //Checks if an account registered under the given username exists
         if (user[0] == null)
         {
             res.render("pages/login", {
-                message: "No account exists with that username.",
+                message: failed_login_feedback,
                 error: true
             });
         }
@@ -122,7 +125,7 @@ app.post("/login", (req, res) => {
         const match = await bcrypt.compare(password, user[0].password);
         
         //Checks if password matches
-        if (match)
+        if (match === true)
         {
             req.session.user = username;
             req.session.user.flight_api_key = process.env.flight_api_key;
@@ -132,7 +135,7 @@ app.post("/login", (req, res) => {
         else
         {
             res.render("pages/login", {
-                message: "Incorrect password for given username.",
+                message: failed_login_feedback,
                 error: true,
             });
         }

--- a/All project code/index.js
+++ b/All project code/index.js
@@ -101,7 +101,7 @@ app.get("/login", (req, res) => {
 });
 
 // Handles showing the user feedback on a failed login attempt.
-function failedLogin() {
+function failedLogin(res) {
     // For security reasons, the user should receieve the same feedback on a login fail, regardless of why the login failed.
     res.render("pages/login", {
         message: "Incorrect username or password.",
@@ -123,7 +123,7 @@ app.post("/login", async (req, res) => {
         //Checks if an account registered under the given username exists
         if (user[0] == null)
         {
-            failedLogin();
+            failedLogin(res);
             // early return to prevent race-conditions due to asynchronous behavior
             return;
         }
@@ -143,13 +143,13 @@ app.post("/login", async (req, res) => {
             return;
         }
 
-        failedLogin();
+        failedLogin(res);
         // early return to prevent race-conditions due to asynchronous behavior
         return;
     })
     .catch((err) => {
         console.log(err.message);
-        failedLogin();
+        failedLogin(res);
         // early return to prevent race-conditions due to asynchronous behavior
         return;
     });

--- a/All project code/index.js
+++ b/All project code/index.js
@@ -100,52 +100,58 @@ app.get("/login", (req, res) => {
     res.render("pages/login");
 });
 
+// Handles showing the user feedback on a failed login attempt.
+function failedLogin() {
+    // For security reasons, the user should receieve the same feedback on a login fail, regardless of why the login failed.
+    res.render("pages/login", {
+        message: "Incorrect username or password.",
+        error: true
+    });
+}
+
 // Handles user login from a /login POST request.
-app.post("/login", (req, res) => {
+app.post("/login", async (req, res) => {
     const username = req.body.username;
     const password = req.body.password;
 
     const query = "SELECT * FROM users WHERE username = $1";
-    // For security reasons, the user should receieve the same feedback on a login fail, regardless of why the login failed.
-    const failed_login_feedback = "Incorrect username or password."
 
     // Queries the database for existing users, and then checks if password matches before logging in.
-    db.any(query, [username])
+    await db.any(query, [username])
     .then(async (user) => {
 
         //Checks if an account registered under the given username exists
         if (user[0] == null)
         {
-            res.render("pages/login", {
-                message: failed_login_feedback,
-                error: true
-            });
+            failedLogin();
+            // early return to prevent race-conditions due to asynchronous behavior
+            return;
         }
 
         const match = await bcrypt.compare(password, user[0].password);
         
         //Checks if password matches
+        // Note: == is not the same as === in javascript. The former does a typecast before checking equality, the latter actually checks equality.
         if (match === true)
         {
             req.session.user = username;
             req.session.user.flight_api_key = process.env.flight_api_key;
             req.session.save();
             res.redirect("/main");
+
+            // early return to prevent race-conditions due to asynchronous behavior
+            return;
         }
-        else
-        {
-            res.render("pages/login", {
-                message: failed_login_feedback,
-                error: true,
-            });
-        }
+
+        failedLogin();
+        // early return to prevent race-conditions due to asynchronous behavior
+        return;
     })
     .catch((err) => {
         console.log(err.message);
-        res.render("pages/login", {
-            message: failed_login_feedback,
-            error: true,
-        });
+        failedLogin();
+        // early return to prevent race-conditions due to asynchronous behavior
+        return;
     });
 });
 


### PR DESCRIPTION
Closes #50 
Currently, the user can tell if a user is or is not registered based on failed login attempt. This is poor security, and allows brute force attempts to check for existing users before trying passwords.

The registration page will still block duplicate usernames, but it isn't as easily brute forced because a successful registration will make a valid user on the database (before feedback is given), which at least requires minimal effort to take account of when trying to brute force logins.

This PR simply makes the login failed feedback equivalent, and patches the race conditions present from handling the database queries synchronously (by restoring the asynchronous behavior, and adding awaits and returns.) 